### PR TITLE
Change Helm apiVersion from v2 to v1 so that Argo CD can use it

### DIFF
--- a/argo-cd-bridges/gitlab/helm/Chart.yaml
+++ b/argo-cd-bridges/gitlab/helm/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 name: gitlab-argo-bridge
 description: A Helm chart which builds and deploys a CronJob that syncs GitLab projects (in a group) with an ArgoCD instance
 


### PR DESCRIPTION
### What does this PR do?
Changes the version of Helm in the gitlab-argo integration piece. Argo CD can only deploy Helm v1 charts. This should not affect anything else and can still be deployed with the Helm 3 CLI.

### How should this be tested?
Deploying the Helm chart for it should do it!

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/tool-integrations
