### PR TITLE
Flat deployment

### DIFF
--- a/argo-cd-bridges/gitlab/deploy/buildconfig.yaml
+++ b/argo-cd-bridges/gitlab/deploy/buildconfig.yaml
@@ -1,0 +1,34 @@
+# Source: gitlab-argo-bridge/templates/build.yaml
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: gitlab-argo-bridge
+  name: gitlab-argo-bridge
+spec:
+  failedBuildsHistoryLimit: 5
+  nodeSelector: {}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: gitlab-argo-bridge:latest
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/redhat-cop/tool-integrations.git
+      ref: master
+    type: Git
+    contextDir: "/argo-cd-bridges/gitlab"
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: python:3.6
+        namespace: openshift
+    type: Source
+  successfulBuildsHistoryLimit: 5
+  triggers:
+  - type: ImageChange
+  - type: ConfigChange

--- a/argo-cd-bridges/gitlab/deploy/configmap.yaml
+++ b/argo-cd-bridges/gitlab/deploy/configmap.yaml
@@ -1,0 +1,11 @@
+# kind: ConfigMap 
+# apiVersion: v1 
+# metadata:
+#   name: gitlab-argo-bridge
+# data:
+#   ARGO_NAMESPACE: argo-cd
+#   DESTINATION_NAMESPACE: argo-cd
+#   RESOURCE_PREFIX: bridged-app
+#   CHART_PATH: "."
+#   SSH_SECRET_NAME: my-ssh-secret
+#   ARGO_CONFIGMAP_NAME: argocd-cm

--- a/argo-cd-bridges/gitlab/deploy/cronjob.yml
+++ b/argo-cd-bridges/gitlab/deploy/cronjob.yml
@@ -1,0 +1,27 @@
+# Source: gitlab-argo-bridge/templates/cronjob.yaml
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: gitlab-argo-bridge
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - image: gitlab-argo-bridge:latest
+            envFrom:
+            - configMapRef:
+                name: gitlab-argo-bridge
+            - secretRef:
+                name: gitlab-argo-bridge
+            imagePullPolicy: Always
+            name: gitlab-argo-bridge
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          restartPolicy: OnFailure
+          serviceAccount: argocd-application-controller
+          serviceAccountName: argocd-application-controller

--- a/argo-cd-bridges/gitlab/deploy/imagestream.yaml
+++ b/argo-cd-bridges/gitlab/deploy/imagestream.yaml
@@ -1,0 +1,10 @@
+# Source: gitlab-argo-bridge/templates/imagestream.yaml
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: gitlab-argo-bridge
+  name: gitlab-argo-bridge
+spec:
+  lookupPolicy:
+    local: true

--- a/argo-cd-bridges/gitlab/deploy/secret.yaml
+++ b/argo-cd-bridges/gitlab/deploy/secret.yaml
@@ -1,0 +1,9 @@
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: gitlab-argo-bridge
+# type: Opaque
+# stringData:
+#   GITLAB_API_URL: ""
+#   GITLAB_PERSONAL_ACCESS_TOKEN: ""
+#   RESIDENCIES_PARENT_REPOSITORIES_ID: ""


### PR DESCRIPTION
### What does this PR do?
Adds a "flat file" deployment of the GitLab Argo bridge. It is intended to be deployed in concert with a secret and a configmap which sets everything up.

### How should this be tested?
`oc apply -f deploy`, and add the example (commented out) secret and configmap with valid values.

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/tool-integrations @oybed 
