### PR TITLE
Add gitlab group config

### DIFF
--- a/argo-cd-bridges/gitlab/app.py
+++ b/argo-cd-bridges/gitlab/app.py
@@ -184,7 +184,8 @@ def add_application_to_argo(project, application_data) -> None:
             SSH_SECRET_NAME=ssh_secret_name,
         )
         if "repository.credentials" in config_map.data.keys():
-            entry_exists = [element for element in config_map.data["repository.credentials"] if element["url"] == gitlab_group_url]
+            existing_credentials = yaml.load(config_map.data["repository.credentials"])
+            entry_exists = [element for element in existing_credentials if element["url"] == gitlab_group_url]
             if len(entry_exists) == 0:
                 # Need to add group config
                 config_map.data["repository.credentials"] += "\n" + group_config

--- a/argo-cd-bridges/gitlab/app.py
+++ b/argo-cd-bridges/gitlab/app.py
@@ -30,10 +30,7 @@ else:
     use_plugins = False
     plugin_directory = ""
 
-if "ADD_KEY_BY_GITLAB_GROUP" in os.environ and os.environ["ADD_KEY_BY_GITLAB_GROUP"] == "true":
-    add_by_gitlab_group = True
-else:
-    add_by_gitlab_group = False
+add_by_gitlab_group = "ADD_KEY_BY_GITLAB_GROUP" in os.environ and os.environ["ADD_KEY_BY_GITLAB_GROUP"] == "true"
 gitlab_group_url = ""
 
 application_template = Template("""apiVersion: argoproj.io/v1alpha1

--- a/argo-cd-bridges/gitlab/helm/templates/cronjob.yaml
+++ b/argo-cd-bridges/gitlab/helm/templates/cronjob.yaml
@@ -27,6 +27,8 @@ spec:
               value: {{ .Values.sshSecretName }}
             - name: ARGO_CONFIGMAP_NAME
               value: {{ .Values.argoConfigMapName }}
+            - name: ADD_KEY_BY_GITLAB_GROUP
+              value: {{ .Values.addKeyByGitLabGroup }}
             {{- if .Values.processRepositoryCondition }}
             - name: PROCESS_REPOSITORY_CONDITION
               value: {{ .Values.processRepositoryCondition | quote }}

--- a/argo-cd-bridges/gitlab/helm/values.yaml
+++ b/argo-cd-bridges/gitlab/helm/values.yaml
@@ -40,3 +40,6 @@ argoConfigMapName: argocd-cm
 
 # The namespace you want Argo to deploy discovered Helm charts to (Application resources will always be created in the namespace Argo lives in)
 destinationNamespace: deploy-helm-charts-here
+
+# If true, adds one single SSH key to the Argo config to be used for all repositories in the GitLab group. Else, adds one key _per_ repository added.
+addKeyByGitLabGroup: true


### PR DESCRIPTION
### What does this PR do?

Defaults to new behavior for reconfiguring Argo for private repositories - which is to use the `repository.credentials` key in the configmap instead of configuring individual entries in the `repositories` key. This allows us to avoid "making a mess" out of Argo's config by not having to modify it for every repository that we add.

### How should this be tested?
Deploy using the Helm chart

### Is there a relevant Issue open for this?
resolves #15 

### Other Relevant info, PRs, etc.

### People to notify
cc: @pabrahamsson @oybed @tylerauerbeck 
