### PR TITLE
Resource Dispatcher: Add support for specifying Git ref on required repositories

### DIFF
--- a/resource-dispatcher/documentation/configuration/repositories.md
+++ b/resource-dispatcher/documentation/configuration/repositories.md
@@ -12,7 +12,10 @@ repositories:
       ssh_private_key: /my/path/to/an/ssh/key
   - name: automation-repo-2
     url: https://github.com/my-org/some-ansible-playbooks-2.git
+    ref: integration
 ```
+
+Both `ref` and `secret.ssh_private_key` are optional, to be used when a Git ref other than `master` is desired, or an SSH pull secret is required, respectively.
 
 Upon application startup, these repositories are cloned. They can be referenced from that point forward by their name as defined here, _not_ by any part of their Git URL.
 

--- a/resource-dispatcher/repositories/__init__.py
+++ b/resource-dispatcher/repositories/__init__.py
@@ -17,8 +17,9 @@ def configure_repository(repository):
 
     if not os.path.exists(repo_directory):
         os.makedirs(repo_directory)
+        ref = repository["ref"] if "ref" in repository else "master"
         print(f"Cloning {repository['url']}...")
-        repo = Repo.clone_from(repository["url"], repo_directory, branch="master", env=env)
+        repo = Repo.clone_from(repository["url"], repo_directory, branch=ref, env=env)
         print(f"Cloned {repository['url']}")
     else:
         repo = Repo.init(repo_directory)


### PR DESCRIPTION
### What does this PR do?
Makes it so that required repositories can be pulled by `ref` instead of always pulling `master`.

### How should this be tested?
Run a config file that has a ref set

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.

### People to notify
cc: @tylerauerbeck @pabrahamsson @oybed 
