### PR TITLE
Reorg Dispatcher Ansible runner to support custom module loading

### DIFF
--- a/resource-dispatcher/execution/plugins/ansible.py
+++ b/resource-dispatcher/execution/plugins/ansible.py
@@ -8,43 +8,47 @@ from ansible.plugins.callback import CallbackBase
 from ansible import context
 import yaml
 import json
+import os
+import subprocess
 
 
 def process(ctx, params):
     playbook_path = params["playbook_path"] if "playbook_path" in params else "site.yml"
     inventory_path = params["inventory_path"] if "inventory_path" in params else "inventory/hosts"
     connection = params["connection"] if "connection" in params else "local"
-    become = params["become"] if "become" in params else None
+    become = params["become"] if "become" in params else False
     become_method = params["become_method"] if "become_method" in params else None
     become_user = params["become_user"] if "become_user" in params else None
     extra_vars = dict(ctx)
     if "extra_vars" in params:
         extra_vars.update(params["extra_vars"])
+        if "ansible_python_interpreter" not in params["extra_vars"]:
+            extra_vars.update({"ansible_python_interpreter": "/opt/app-root/bin/python"}) # Use the Python that we're running as by default, so dependencies are available
 
     loader = DataLoader()
     passwords = dict(vault_pass=params["vault_password"] if "vault_password" in params else "")
 
-    context.CLIARGS = ImmutableDict(connection=connection, module_path=['.'], forks=10, become=become,
+    context.CLIARGS = ImmutableDict(connection=connection, module_path=["./library"], forks=10, become=become,
                                     become_method=become_method, become_user=become_user, check=False, diff=False)
     # results_callback = ResultCallback()
     inventory = InventoryManager(loader=loader, sources=[inventory_path])
     variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+    tqm = TaskQueueManager(
+        inventory=inventory,
+        variable_manager=variable_manager,
+        loader=loader,
+        passwords=passwords,
+        # stdout_callback=results_callback,
+        # Use our custom callback instead of the ``default`` callback plugin, which prints to stdout
+    )
 
     with open(playbook_path, 'r') as file:
         playbook_str = file.read()
     playbook_data = yaml.load(playbook_str, Loader=yaml.FullLoader)
     plays = [play.Play().load(data=play_data, variable_manager=variable_manager, loader=loader, vars=extra_vars) for play_data in playbook_data]
 
-    tqm = None
     try:
-        tqm = TaskQueueManager(
-            inventory=inventory,
-            variable_manager=variable_manager,
-            loader=loader,
-            passwords=passwords,
-            # stdout_callback=results_callback,
-            # Use our custom callback instead of the ``default`` callback plugin, which prints to stdout
-        )
         for play_data in plays:
             result = tqm.run(play_data)
     finally:

--- a/resource-dispatcher/execution/plugins/ansible.py
+++ b/resource-dispatcher/execution/plugins/ansible.py
@@ -8,8 +8,6 @@ from ansible.plugins.callback import CallbackBase
 from ansible import context
 import yaml
 import json
-import os
-import subprocess
 
 
 def process(ctx, params):


### PR DESCRIPTION
Move TaskQueueManager init to before play load so that CLIARGS are respected, set "become" correctly, default to running playbooks with the same Python version that the dispatcher is running as.

### What does this PR do?
Fixes Ansible plugin to support custom modules in the `./library` directory in relation to the playbook.

### How should this be tested?
Run a playbook with a custom module using the dispatcher

### Is there a relevant Issue open for this?

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/tool-integrations
