### PR TITLE
[Dispatcher] Deep merge params with params_from_context

### DIFF
--- a/resource-dispatcher/execution/__init__.py
+++ b/resource-dispatcher/execution/__init__.py
@@ -68,9 +68,9 @@ def execute_step(fn, step, context):
     if loop_over is None:
         constructed_params = {}
         if "params_from_context" in step:
-            constructed_params.update(context[step["params_from_context"]])
+            deep_merge(constructed_params, context[step["params_from_context"]])
         if "params" in step:
-            constructed_params.update(step["params"])
+            deep_merge(constructed_params, step["params"])
         return fn(context, constructed_params)
     else:
         if isinstance(context[loop_over], list):
@@ -99,6 +99,20 @@ def execute_step(fn, step, context):
             return True
         else:
             raise Exception("Error: Tried to loop over a non-iterable context object.")
+
+
+def deep_merge(merge_into, merge_from, path=None):
+    if path is None: path = []
+    for key in merge_from:
+        if key in merge_into:
+            if isinstance(merge_from[key], dict) and isinstance(merge_into[key], dict):
+                deep_merge(merge_into[key], merge_from[key], path + [str(key)])
+            elif merge_into[key] == merge_from[key]:
+                pass
+            else:
+                raise Exception('Cannot merge dictionary with non-dictionary element: %s' % '.'.join(path + [str(key)]))
+        else:
+            merge_into[key] = merge_from[key]
 
 
 def handle_errors(task):


### PR DESCRIPTION
### What does this PR do?
Makes it so that params further than one level deep (such as Ansible's `extra_vars.<stuff>`) are more intelligently merged between statically-defined `params` and dynamic `params_from_context`.

### How should this be tested?
Run it with a config that sources inputs more than one level deep from `params` and `params_from_context` at the same time. For example:

```yaml
tasks:
  - name: merge-test
    triggers:
      - type: scheduled
        every: 10 minutes
    steps:
      - plugin: script
        params:
          script: |
            context["ansible"] = {
              "extra_vars": {
                "var_1": 1,
                "var_2": 2
              }
            }
      - plugin: ansible
        repository: my-automation
        params_from_context: ansible
        params:
          playbook_path: site.yml
          inventory_path: inventory
          extra_vars:
            var_3: 3
            var_4: 4
```

and ensure that the plugin runs with all of those parameters defined

### Is there a relevant Issue open for this?

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/tool-integrations
