### PR TITLE
[Dispatcher] Wrap the repo pull in an error handler

### DIFF
--- a/resource-dispatcher/repositories/__init__.py
+++ b/resource-dispatcher/repositories/__init__.py
@@ -40,6 +40,9 @@ def generate_ssh_command(repository):
 def __wrap_repo_pull(repo, ref, env):
 
     def pull():
-        repo.remotes.origin.pull(ref, env=env)
+        try:
+            repo.remotes.origin.pull(ref, env=env)
+        except Exception as e:
+            print(f"ERROR: Could not fetch the latest copy of a repository ({e})")
 
     return pull


### PR DESCRIPTION
### What does this PR do?
A network issue preventing the repo pull from succeeding should not crash the app.

### How should this be tested?
Run the dispatcher and disconnect the network

### Is there a relevant Issue open for this?

### Other Relevant info, PRs, etc.

### People to notify
cc: @redhat-cop/tool-integrations
