### PR TITLE
Add print statements and remove unused vars to resource-dispatcher

### DIFF
--- a/resource-dispatcher/execution/plugins/git.py
+++ b/resource-dispatcher/execution/plugins/git.py
@@ -27,9 +27,9 @@ def run_action(params):
     if params["action"] == "clone" or params["action"] == "pull":
         fetch(url, repo_directory, branch, env)
     elif params["action"] == "add-all-changes":
-        add_all(repo_directory)
+        add_all(url, repo_directory)
     elif params["action"] == "commit":
-        commit(repo_directory, message, author_name, author_email)
+        commit(url, repo_directory, message, author_name, author_email)
     elif params["action"] == "push":
         push(url, repo_directory, env)
 
@@ -48,24 +48,22 @@ def fetch(url, repo_directory, branch, env={}):
         repo.remotes.origin.pull(env=env)
 
 
-def add_all(repo_directory):
+def add_all(url, repo_directory):
     repo = Repo.init(repo_directory)
     repo.git.add(all=True)
-    print("All files added")
+    print(f"All files added: {url}")
 
 
-def commit(repo_directory, message, author_name, author_email):
+def commit(url, repo_directory, message, author_name, author_email):
     repo = Repo.init(repo_directory)
     repo.config_writer().set_value("user", "name", author_name).release()
     repo.config_writer().set_value("user", "email", author_email).release()
     try:
         repo.git.commit("-m", message, author=f"{author_name} <{author_email}>")
-        print("Committed to repository")
+        print(f"Committed to repository: {url}")
     except Exception as e:
-        if "nothing to commit, working tree clean" in str(e):
-            print("Nothing to commit")
-        elif "nothing to commit" in str(e):
-            print("Nothing to commit, empty repository?")
+        if "nothing to commit" in str(e):
+            print(f"Nothing to commit: {url}")
         else:
             raise e
 
@@ -74,6 +72,6 @@ def push(url, repo_directory, env={}):
     repo = Repo.init(repo_directory)
     try:
         repo.remotes.origin.push(env=env)
-        print("Pushed repository")
+        print(f"Pushed repository: {url}")
     except Exception as e:
         print(e)

--- a/resource-dispatcher/execution/plugins/git.py
+++ b/resource-dispatcher/execution/plugins/git.py
@@ -14,20 +14,20 @@ def run_action(params):
     branch = params["branch"] if "branch" in params else "master"
     message = params["message"] if "message" in params else "Commit message"
     author_name = params["author_name"] if "author_name" in params else "Automated Tool"
-    author_email = params["author_email"] if "author_email" in params else "email@email.com"
+    author_email = (
+        params["author_email"] if "author_email" in params else "email@email.com"
+    )
     url = params["url"] if "url" in params else None
 
     if "secret" in params and url and not url.startswith("http"):
-        env = {
-            "GIT_SSH_COMMAND": generate_ssh_command(params)
-        }
+        env = {"GIT_SSH_COMMAND": generate_ssh_command(params)}
     else:
         env = {}
 
     if params["action"] == "clone" or params["action"] == "pull":
-        repo = fetch(url, repo_directory, branch, env)
+        fetch(url, repo_directory, branch, env)
     elif params["action"] == "add-all-changes":
-        repo = add_all(repo_directory)
+        add_all(repo_directory)
     elif params["action"] == "commit":
         commit(repo_directory, message, author_name, author_email)
     elif params["action"] == "push":
@@ -37,20 +37,21 @@ def run_action(params):
 def fetch(url, repo_directory, branch, env={}):
     if not os.path.exists(repo_directory):
         os.makedirs(repo_directory)
-        print(f"Cloning {url}...")
-        repo = Repo.clone_from(url, repo_directory, branch=branch, env=env)
-        print(f"Cloned {url}")
+        try:
+            print(f"Cloning {url}...")
+            Repo.clone_from(url, repo_directory, branch=branch, env=env)
+            print(f"Cloned {url}")
+        except:
+            pass
     else:
         repo = Repo.init(repo_directory)
         repo.remotes.origin.pull(env=env)
-    return repo
 
 
 def add_all(repo_directory):
     repo = Repo.init(repo_directory)
     repo.git.add(all=True)
     print("All files added")
-    return repo
 
 
 def commit(repo_directory, message, author_name, author_email):
@@ -58,16 +59,21 @@ def commit(repo_directory, message, author_name, author_email):
     repo.config_writer().set_value("user", "name", author_name).release()
     repo.config_writer().set_value("user", "email", author_email).release()
     try:
-        repo.git.commit('-m', message, author=f"{author_name} <{author_email}>")
+        repo.git.commit("-m", message, author=f"{author_name} <{author_email}>")
         print("Committed to repository")
     except Exception as e:
         if "nothing to commit, working tree clean" in str(e):
             print("Nothing to commit")
+        elif "nothing to commit" in str(e):
+            print("Nothing to commit, empty repository?")
         else:
             raise e
 
 
 def push(url, repo_directory, env={}):
     repo = Repo.init(repo_directory)
-    repo.remotes.origin.push(env=env)
-    print("Pushed repository")
+    try:
+        repo.remotes.origin.push(env=env)
+        print("Pushed repository")
+    except Exception as e:
+        print(e)

--- a/resource-dispatcher/execution/plugins/git.py
+++ b/resource-dispatcher/execution/plugins/git.py
@@ -37,12 +37,17 @@ def run_action(params):
 def fetch(url, repo_directory, branch, env={}):
     if not os.path.exists(repo_directory):
         os.makedirs(repo_directory)
+        print(f"Cloning {url}...")
         try:
-            print(f"Cloning {url}...")
-            Repo.clone_from(url, repo_directory, branch=branch, env=env)
+            repo = Repo.clone_from(url, repo_directory, branch=branch, env=env)
             print(f"Cloned {url}")
-        except:
-            pass
+        except Exception as e:
+            if "not found in upstream origin" in str(e):
+                print(f"Branch {branch} not found: {url}")
+            elif "The project you were looking for could not be found" in str(e):
+                print(f"Project not found: {url}")
+            else:
+                raise e
     else:
         repo = Repo.init(repo_directory)
         repo.remotes.origin.pull(env=env)
@@ -69,9 +74,12 @@ def commit(url, repo_directory, message, author_name, author_email):
 
 
 def push(url, repo_directory, env={}):
-    repo = Repo.init(repo_directory)
     try:
+        repo = Repo.init(repo_directory)
         repo.remotes.origin.push(env=env)
         print(f"Pushed repository: {url}")
     except Exception as e:
-        print(e)
+        if "object has no attribute 'origin'" in str(e):
+            print(f"Remote origin does not exist: {url}")
+        else:
+            raise e


### PR DESCRIPTION
### What does this PR do?

Removes unused vars and return statements while adding more data to print statements. Currently empty repositories, or repositories without a master branch cause the tool to hang.

Additionally added more info to some of the print statements on the git plugin, for example:

```
All files added: ssh://git@example.com/engagment/iac.git
Pushed repository: ssh://git@example.com/engagment/iac.git
```

### People to notify
cc: @redhat-cop/tool-integrations
