### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
### What does this PR do?
This PR configures Dependabot to also watch GH Actions and allows it to open a PR if we're using old versions of Actions

### How should this be tested?
Nothing to test. After merge, this will begin to watch the repo for out of date actions. This can be seen here: https://github.com/tylerauerbeck/charts-3/pull/1

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @redhat-cop/tool-integrations
