### PR TITLE
Follow symlinks when copying automation repositories

### DIFF
--- a/resource-dispatcher/execution/__init__.py
+++ b/resource-dispatcher/execution/__init__.py
@@ -42,7 +42,7 @@ def task_function(task, context):
         with tempfile.TemporaryDirectory() as temp_dir:
             if os.path.exists("tmp"):
                 for repository in [f.name for f in os.scandir("tmp") if f.is_dir()]:
-                    shutil.copytree("tmp/" + repository, temp_dir + "/" + repository)
+                    shutil.copytree("tmp/" + repository, temp_dir + "/" + repository, symlinks=True)
             with cd(temp_dir):
                 for step in task["steps"]:
                     # Load necessary execution plugin


### PR DESCRIPTION
### What does this PR do?
Allows resource-dispatcher to clone and copy repositories containing symlinks with `shutil.copytree`

### How should this be tested?
The infra-ansible repository is an example of one that will fail at this step due to symlinks that will recurse to an infinite path.

```bash
repositories:
  - name: infra-ansible
    url: https://github.com/redhat-cop/infra-ansible.git
    ref: main
```

This seems to run immediately when the first task is received by the dispatcher and will cause the /tmp dir to recursively fill up with symlinks, for example:

```bash
$ ls -alh roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/roles/rhsm/tests/
total 20K
drwxrwxr-x. 3 xxx xxx 4.0K Jan 27 10:44 .
drwxrwxr-x. 4 xxx xxx 4.0K Jan 27 10:44 ..
drwxrwxr-x. 2 xxx xxx 4.0K Jan 27 10:44 group_vars
-rw-rw-r--. 1 xxx xxx   75 Jan 27 10:44 inventory
lrwxrwxrwx. 1 xxx xxx   14 Jan 27 10:44 roles -> ../../../roles
-rw-rw-r--. 1 xxx xxx  111 Jan 27 10:44 test.yml
```

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/tool-integrations
