### PR TITLE
Wrap webhook payload dict to avoid collisions

### DIFF
--- a/resource-dispatcher/execution/plugins/ansible-runner.py
+++ b/resource-dispatcher/execution/plugins/ansible-runner.py
@@ -8,7 +8,9 @@ def process(ctx, params):
     inventory_path = (
         params["inventory_path"] if "inventory_path" in params else "inventory/hosts"
     )
-    extra_vars = dict(ctx)
+    extra_vars = dict(
+        webhook_payload=ctx
+    )
     if "extra_vars" in params:
         extra_vars.update(params["extra_vars"])
         # Use the Python that we're running as by default, so dependencies are available


### PR DESCRIPTION
### What does this PR do?
Moves the webhook payload into its own dict rather than top level:

Before:

```yaml
project:
  avatar_url: null
  ci_config_path: null
  default_branch: master
  description: ''
  git_http_url: >-
    https://example.com/example/repo.git
```

After:
```yaml
webhook_payload:
  project:
    avatar_url: null
    ci_config_path: null
    default_branch: master
    description: ''
    git_http_url: >-
      https://example.com/example/repo.git
```

Note that this only affects the new ansible-runner plugin and not any other existing config scripts or automation playbooks.

### People to notify
cc: @redhat-cop/tool-integrations
