### PR TITLE
Resource Dispatcher: Add resources to Helm chart

### DIFF
--- a/resource-dispatcher/helm/templates/deploymentconfig.yaml
+++ b/resource-dispatcher/helm/templates/deploymentconfig.yaml
@@ -11,7 +11,8 @@ spec:
     deploymentconfig: {{ include "app.fullname" . }}
   strategy:
     activeDeadlineSeconds: 21600
-    resources: {}
+    resources:
+      {{- toYaml .Values.resources | nindent 6 }}
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%

--- a/resource-dispatcher/helm/templates/deploymentconfig.yaml
+++ b/resource-dispatcher/helm/templates/deploymentconfig.yaml
@@ -12,7 +12,7 @@ spec:
   strategy:
     activeDeadlineSeconds: 21600
     resources:
-      {{- toYaml .Values.resources | nindent 6 }}
+    {{- toYaml .Values.resources | nindent 6 }}
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%

--- a/resource-dispatcher/helm/templates/deploymentconfig.yaml
+++ b/resource-dispatcher/helm/templates/deploymentconfig.yaml
@@ -52,7 +52,8 @@ spec:
         ports:
         - containerPort: 5000
           protocol: TCP
-        resources: {}
+        resources:
+        {{- toYaml .Values.resources | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/resource-dispatcher/helm/values.yaml
+++ b/resource-dispatcher/helm/values.yaml
@@ -18,3 +18,5 @@ useServiceAccount: false
 
 useConfigDir: false
 configMapAsEnvVars: false
+
+resources: {}


### PR DESCRIPTION
### What does this PR do?

Adds resources values to Helm Chart for resource dispatcher.

### How should this be tested?

Add override values to Helm Chart params.

```yaml
  resources:
    limits:
      cpu: 500m
      memory: 1Gi
    requests:
      cpu: 250m
      memory: 512Mi
```

### Is there a relevant Issue open for this?

N/A

### Other Relevant info, PRs, etc.

None

### People to notify

cc: @redhat-cop/tool-integrations
